### PR TITLE
Harden injury API input and data parsing handling

### DIFF
--- a/flask_api.py
+++ b/flask_api.py
@@ -23,6 +23,8 @@ def load_injuries() -> List[Dict[str, Any]]:
             return json.load(f)
     except FileNotFoundError:
         return []
+    except json.JSONDecodeError:
+        return []
 
 
 @app.route('/')
@@ -53,6 +55,9 @@ def get_all_injuries():
     """
     injuries = load_injuries()
     limit = request.args.get('limit', 100, type=int)
+    if limit is None:
+        limit = 100
+    limit = max(1, limit)
     
     return jsonify({
         'success': True,
@@ -95,7 +100,7 @@ def get_injury_by_player(player_id: str):
     injuries = load_injuries()
     player_injuries = [
         injury for injury in injuries 
-        if injury.get('player_id') == player_id
+        if str(injury.get('player_id', '')) == str(player_id)
     ]
     
     if player_injuries:


### PR DESCRIPTION
### Motivation
- Prevent the API from crashing or returning unexpected results when `nba_injuries.json` is missing or malformed and to make query handling more robust for external inputs.

### Description
- Added `json.JSONDecodeError` handling in `load_injuries()` to return an empty list for malformed JSON files.
- Validated and normalized the `limit` query parameter in `/api/injuries` so `None` or negative values are coerced to a sensible minimum (`1`).
- Made `/api/injuries/player/<player_id>` comparisons type-robust by converting stored and incoming `player_id` values to `str` before comparing.

### Testing
- Ran `python -m compileall flask_api.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd273ddd78832590b6e529bd23adba)