### PR TITLE
Harden ESPN defensive metrics parsing to avoid null defense_data

### DIFF
--- a/predict_games.py
+++ b/predict_games.py
@@ -151,29 +151,78 @@ def get_team_stats(team_id):
 
 def get_team_defense_metrics(team_id):
     """Busca métricas defensivas e de pace do time."""
+    def normalize_metric_value(raw_value):
+        """Converte valores da API (string/number) para float quando possível."""
+        if raw_value is None:
+            return None
+        if isinstance(raw_value, (int, float)):
+            return float(raw_value)
+        if isinstance(raw_value, str):
+            cleaned = raw_value.strip().replace(",", ".")
+            if not cleaned:
+                return None
+            try:
+                return float(cleaned)
+            except ValueError:
+                return None
+        return None
+
+    def iter_stats_objects(payload):
+        """
+        Caminha recursivamente pelo payload e retorna qualquer lista de stats encontrada.
+        Isso evita quebra quando a ESPN altera o shape do JSON.
+        """
+        if isinstance(payload, dict):
+            for key, value in payload.items():
+                if key == "stats" and isinstance(value, list):
+                    yield from value
+                else:
+                    yield from iter_stats_objects(value)
+        elif isinstance(payload, list):
+            for item in payload:
+                yield from iter_stats_objects(item)
+
+    def match_stat_name(stat):
+        name = str(stat.get('name', '')).lower().strip()
+        display_name = str(stat.get('displayName', '')).lower().strip()
+        short_display_name = str(stat.get('shortDisplayName', '')).lower().strip()
+        summary = " ".join([name, display_name, short_display_name])
+
+        if "defensive" in summary and "rating" in summary:
+            return "defensive_rating"
+        if "pace" in summary:
+            return "pace"
+        if "points allowed" in summary or "opp points" in summary or "opponent points" in summary:
+            return "points_allowed"
+        return None
+
     try:
         # ESPN API para estatísticas do time
         url = f"https://site.api.espn.com/apis/site/v2/sports/basketball/nba/teams/{team_id}/statistics"
         res = requests.get(url, timeout=10)
         
         if res.status_code != 200:
+            print(f"⚠️ Endpoint de estatísticas retornou status {res.status_code} para team_id={team_id}")
             return {'defensive_rating': None, 'pace': None, 'points_allowed': None}
         
         data = res.json()
-        stats = data.get('results', {}).get('stats', [])
-        
-        defensive_rating = None
-        pace = None
-        points_allowed = None
-        
-        for stat in stats:
-            name = stat.get('name', '').lower()
-            if 'defensive' in name and 'rating' in name:
-                defensive_rating = stat.get('value')
-            elif 'pace' in name:
-                pace = stat.get('value')
-            elif 'points allowed' in name or 'opp points' in name:
-                points_allowed = stat.get('value')
+        defensive_rating, pace, points_allowed = None, None, None
+
+        for stat in iter_stats_objects(data):
+            metric_name = match_stat_name(stat)
+            if not metric_name:
+                continue
+
+            metric_value = normalize_metric_value(
+                stat.get('value', stat.get('displayValue'))
+            )
+
+            if metric_name == "defensive_rating" and defensive_rating is None:
+                defensive_rating = metric_value
+            elif metric_name == "pace" and pace is None:
+                pace = metric_value
+            elif metric_name == "points_allowed" and points_allowed is None:
+                points_allowed = metric_value
         
         return {
             'defensive_rating': defensive_rating,


### PR DESCRIPTION
### Motivation
- `game_predictions.defense_data` was frequently saved with `null` values because `get_team_defense_metrics` assumed a single JSON shape and a rigid metric name format from the ESPN statistics endpoint. 
- The goal is to make defensive metric extraction resilient to variations in the ESPN response so `home_def_rating` / `away_def_rating` are reliably populated when data exists.

### Description
- Updated `predict_games.py` to add robust parsing in `get_team_defense_metrics`, including recursive discovery of any `stats` lists in the payload. 
- Added `normalize_metric_value` to coerce string or numeric metric values to `float` and handle empty or localized formats (commas). 
- Added `match_stat_name` which checks `name`, `displayName`, and `shortDisplayName` to identify `defensive_rating`, `pace`, and `points_allowed`. 
- Log a warning when the ESPN statistics endpoint returns a non-200 status and return safe `None` metrics in that case; also reviewed `.github/workflows/update_data.yml` to confirm env vars are already provided for running `predict_games.py`.

### Testing
- Ran `python -m py_compile predict_games.py` which completed successfully. 
- Attempted a live `requests.get` against the ESPN statistics endpoint to validate extraction end-to-end, but the request failed in this environment with a proxy error (`Tunnel connection failed: 403 Forbidden`), so full runtime validation against ESPN payloads could not be completed here. 
- No unit tests were present or modified; code changes were limited to `predict_games.py` and verified for syntax correctness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1e91f8d0483258aab94e45e2938da)