### PR TITLE
Harden Databallr parser fallback and fix workflow date validation

### DIFF
--- a/.github/workflows/databallr_scraper.yml
+++ b/.github/workflows/databallr_scraper.yml
@@ -59,14 +59,14 @@ jobs:
           cat << 'EOF' > validate.py
           import os, sys
           from supabase import create_client
-          from datetime import datetime, timezone, timedelta
+          from datetime import datetime, timezone
           
           url = os.environ.get("SUPABASE_URL")
           key = os.environ.get("SUPABASE_SERVICE_KEY")
           client = create_client(url, key)
           
-          # Âncora temporal BRT (UTC-3)
-          today = (datetime.now(timezone.utc) - timedelta(hours=3)).date().isoformat()
+          # Âncora temporal UTC para alinhar com record_date do scraper
+          today = datetime.now(timezone.utc).date().isoformat()
           
           res = client.table('databallr_team_stats').select('id').eq('record_date', today).execute()
           if len(res.data) == 0:

--- a/scraper_databallr.py
+++ b/scraper_databallr.py
@@ -10,6 +10,7 @@ import json
 import logging
 import re
 from datetime import datetime, timezone
+from json import JSONDecodeError
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -70,6 +71,22 @@ class DataballrScraper:
         except (ValueError, TypeError):
             return 0.0
 
+    def _extract_teams_from_next_data(self, soup: BeautifulSoup) -> list[dict]:
+        """Extrair payload de times do bloco __NEXT_DATA__ com tolerância a falhas."""
+        script_tag = soup.find('script', id='__NEXT_DATA__')
+        if not script_tag or not script_tag.string:
+            return []
+
+        try:
+            payload = json.loads(script_tag.string)
+        except JSONDecodeError:
+            logger.warning("[VAL-WARN] __NEXT_DATA__ inválido. Fallback para parser DOM.")
+            return []
+
+        page_props = payload.get('props', {}).get('pageProps', {})
+        teams = page_props.get('teams') or page_props.get('initialData', {}).get('teams', [])
+        return teams if isinstance(teams, list) else []
+
     def fetch_data(self) -> pd.DataFrame:
         """Execução da Malha Híbrida de Extração."""
         logger.info(f"[NET-FETCH] Alvo: {self.base_url}/stats")
@@ -81,27 +98,22 @@ class DataballrScraper:
             soup = BeautifulSoup(response.text, 'lxml')
             
             # ESTRATÉGIA A: Desestruturação de Hidratação Next.js
-            script_tag = soup.find('script', id='__NEXT_DATA__')
-            if script_tag:
+            teams = self._extract_teams_from_next_data(soup)
+            if teams:
                 logger.info("[VAL-OK] Bloco __NEXT_DATA__ interceptado.")
-                payload = json.loads(script_tag.string)
-                page_props = payload.get('props', {}).get('pageProps', {})
-                teams = page_props.get('teams') or page_props.get('initialData', {}).get('teams', [])
-                
-                if teams:
-                    return pd.DataFrame([{
-                        'team_id': int(t.get('teamId') or t.get('id', 0)),
-                        'team_name': t.get('teamName') or t.get('name'),
-                        'team_abbreviation': (t.get('teamAbbr') or t.get('abbr') or "NBA").upper(),
-                        'ortg': float(t.get('oRtg') or 0),
-                        'drtg': float(t.get('dRtg') or 0),
-                        'net_rating': float(t.get('netRtg') or 0),
-                        'offense_rating': float(t.get('offense') or 0),
-                        'defense_rating': float(t.get('defense') or 0),
-                        'record_date': self.current_date,
-                        'period': self.period_label,
-                        'created_at': self.current_timestamp
-                    } for t in teams])
+                return pd.DataFrame([{
+                    'team_id': int(t.get('teamId') or t.get('id', 0)),
+                    'team_name': t.get('teamName') or t.get('name'),
+                    'team_abbreviation': (t.get('teamAbbr') or t.get('abbr') or "NBA").upper(),
+                    'ortg': float(t.get('oRtg') or 0),
+                    'drtg': float(t.get('dRtg') or 0),
+                    'net_rating': float(t.get('netRtg') or 0),
+                    'offense_rating': float(t.get('offense') or 0),
+                    'defense_rating': float(t.get('defense') or 0),
+                    'record_date': self.current_date,
+                    'period': self.period_label,
+                    'created_at': self.current_timestamp
+                } for t in teams])
 
             # ESTRATÉGIA B: Fallback de Tabela DOM (Resiliência)
             logger.warning("[VAL-WARN] Hidratação falhou. Acionando Motor de Parsing DOM.")


### PR DESCRIPTION
### Motivation
- Prevent the scraper from crashing when the Next.js hydration block (`__NEXT_DATA__`) is missing, empty, or contains invalid JSON. 
- Ensure the CI workflow validation checks the same UTC `record_date` that the scraper writes to avoid false negatives.

### Description
- Added `JSONDecodeError` import and a resilient helper `DataballrScraper._extract_teams_from_next_data` that safely parses the `__NEXT_DATA__` script and returns an empty list on error. 
- Reworked `fetch_data()` to call the new helper and fall back to DOM table parsing when hydration data is absent or invalid. 
- Updated `.github/workflows/databallr_scraper.yml` validation step to compute `today` in UTC (`datetime.now(timezone.utc).date()`) to align with the scraper's `record_date`. 
- Kept existing Supabase upsert flow and DOM fallback logic unchanged aside from reusing the extracted `teams` payload.

### Testing
- Ran `python -m py_compile scraper_databallr.py` which succeeded. 
- Ran `git diff --check` which returned no problems. 
- Attempted to validate the workflow YAML with a Python `yaml` loader and `yq`, but those tools were not available in the environment so the YAML check was not performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4003a97588325a0a769a1485ea233)